### PR TITLE
Modifying default implementations required for AutoEncoderDemo so the…

### DIFF
--- a/ml4j-layers-impl/pom.xml
+++ b/ml4j-layers-impl/pom.xml
@@ -25,6 +25,16 @@
 			<artifactId>ml4j-layers-api</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.ml4j</groupId>
+			<artifactId>ml4j-synapses-impl</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.ml4j</groupId>
+			<artifactId>ml4j-mock-impl</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/ml4j-layers-impl/src/main/java/org/ml4j/nn/layers/FeedForwardLayerImpl.java
+++ b/ml4j-layers-impl/src/main/java/org/ml4j/nn/layers/FeedForwardLayerImpl.java
@@ -1,85 +1,171 @@
 /*
  * Copyright 2017 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.ml4j.nn.layers;
 
+import org.ml4j.Matrix;
+import org.ml4j.mocks.MatrixFactoryMock;
 import org.ml4j.nn.activationfunctions.DifferentiableActivationFunction;
 import org.ml4j.nn.axons.Axons;
+import org.ml4j.nn.axons.AxonsImpl;
+import org.ml4j.nn.layers.DirectedLayerActivation;
+import org.ml4j.nn.layers.DirectedLayerContext;
+import org.ml4j.nn.layers.FeedForwardLayer;
+import org.ml4j.nn.layers.mocks.DirectedLayerActivationMock;
 import org.ml4j.nn.neurons.Neurons;
 import org.ml4j.nn.neurons.NeuronsActivation;
+import org.ml4j.nn.neurons.NeuronsActivationFeatureOrientation;
 import org.ml4j.nn.synapses.DirectedSynapses;
+import org.ml4j.nn.synapses.mocks.DirectedSynapsesMock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The default ml4j FeedForwardLayer implementation.
+ * A minimal mock skeleton FeedForwardLayer.
  * 
  * @author Michael Lavelle
  */
-public class FeedForwardLayerImpl
-    implements FeedForwardLayer<Axons<?, ?, ?>, FeedForwardLayerImpl> {
+public class FeedForwardLayerImpl implements FeedForwardLayer<Axons<?, ?, ?>, 
+    FeedForwardLayerImpl> {
 
   /**
    * Default serialization id.
    */
   private static final long serialVersionUID = 1L;
+ 
+  private static final Logger LOGGER = 
+      LoggerFactory.getLogger(FeedForwardLayerImpl.class);
 
-  public FeedForwardLayerImpl(Neurons inputNeurons, Neurons outputNeurons,
+  private Axons<?, ?, ?> primaryAxons;
+  
+  private DifferentiableActivationFunction primaryActivationFunction;
+  
+  /**
+   * @param inputNeurons The input Neurons.
+   * @param outputNeurons The output Neurons
+   * @param primaryActivationFunction The primary activation function.
+   */
+  public FeedForwardLayerImpl(Neurons inputNeurons, Neurons outputNeurons, 
       DifferentiableActivationFunction primaryActivationFunction) {
-    throw new UnsupportedOperationException("Not implemented yet");
+      this(new AxonsImpl(inputNeurons, outputNeurons, 
+          createInitialAxonConnectionWeights(inputNeurons, outputNeurons)));
+    this.primaryActivationFunction = primaryActivationFunction;
+  }
+  
+  /**
+   * Obtain the initial axon connection weights.
+   * 
+   * @param inputNeurons The input Neurons
+   * @param outputNeurons The output Neurons
+   * @return The initial conn
+   */
+  private static Matrix createInitialAxonConnectionWeights(Neurons inputNeurons,
+      Neurons outputNeurons) {
+    return new MatrixFactoryMock().createZeros(inputNeurons.getNeuronCountIncludingBias(),
+        outputNeurons.getNeuronCountIncludingBias());
+    // throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  protected FeedForwardLayerImpl(Axons<?, ?, ?> primaryAxons) {
+    this.primaryAxons = primaryAxons;
   }
 
   @Override
   public FeedForwardLayerImpl dup() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return new FeedForwardLayerImpl(primaryAxons);
   }
 
   @Override
   public int getInputNeuronCount() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return primaryAxons.getLeftNeurons().getNeuronCountIncludingBias();
   }
 
   @Override
   public int getOutputNeuronCount() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return primaryAxons.getRightNeurons().getNeuronCountIncludingBias();
   }
 
   @Override
   public Axons<?, ?, ?> getPrimaryAxons() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return primaryAxons;
   }
 
   @Override
   public NeuronsActivation getOptimalInputForOutputNeuron(int outputNeuronIndex,
       DirectedLayerContext directedLayerContext) {
-    throw new UnsupportedOperationException("Not implemented yet");
-  }
+    LOGGER.debug("Mock obtaining optimal input for output neuron with index:" + outputNeuronIndex);
+    int countJ = getPrimaryAxons().getLeftNeurons().getNeuronCountExcludingBias();
+    double[] maximisingInputFeatures = new double[countJ];
+    Matrix weights = ((AxonsImpl) getPrimaryAxons()).getConnectionWeights();
+    boolean hasBiasUnit = getPrimaryAxons().getLeftNeurons().hasBiasUnit();
 
+    for (int j = 0; j < countJ; j++) {
+      double wij = getWij(j, outputNeuronIndex, weights, hasBiasUnit);
+      double sum = 0;
+
+      if (wij != 0) {
+
+        for (int j2 = 0; j2 < countJ; j2++) {
+          double weight = getWij(j2, outputNeuronIndex, weights, hasBiasUnit);
+          if (weight != 0) {
+            sum = sum + Math.pow(weight, 2);
+          }
+        }
+        sum = Math.sqrt(sum);
+      }
+      maximisingInputFeatures[j] = wij / sum;
+    }
+    return new NeuronsActivation(
+        directedLayerContext.getMatrixFactory()
+            .createMatrix(new double[][] {maximisingInputFeatures}),
+        false, NeuronsActivationFeatureOrientation.COLUMNS_SPAN_FEATURE_SET);
+  }
+  
+  private double getWij(int indI, int indJ, Matrix weights, boolean hasBiasUnit) {
+    int indICorrected = indI + (hasBiasUnit ? 1 : 0);
+    return weights.get(indICorrected, indJ);
+  }
 
   @Override
   public DifferentiableActivationFunction getPrimaryActivationFunction() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return primaryActivationFunction;
   }
 
   @Override
   public DirectedLayerActivation forwardPropagate(NeuronsActivation inputNeuronsActivation,
       DirectedLayerContext directedLayerContext) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    LOGGER.debug("Forward propagating through layer");
+   
+    NeuronsActivation inFlightNeuronsActivation = inputNeuronsActivation;
+    
+    for (DirectedSynapses<?> synapses : getSynapses()) {
+      inFlightNeuronsActivation = synapses.forwardPropagate(inFlightNeuronsActivation, 
+              directedLayerContext.createSynapsesContext()).getOutput();
+    }
+ 
+    return new DirectedLayerActivationMock(inFlightNeuronsActivation);
   }
 
   @Override
   public List<DirectedSynapses<?>> getSynapses() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    List<DirectedSynapses<?>> synapses = new ArrayList<>();
+    synapses.add(new DirectedSynapsesMock(getPrimaryAxons(), getPrimaryActivationFunction()));
+    return synapses;
   }
 }

--- a/ml4j-matrices-impl/pom.xml
+++ b/ml4j-matrices-impl/pom.xml
@@ -25,6 +25,11 @@
 			<artifactId>ml4j-matrices-api</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.ml4j</groupId>
+			<artifactId>ml4j-mock-impl</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/ml4j-matrices-impl/src/main/java/org/ml4j/MatrixFactoryImpl.java
+++ b/ml4j-matrices-impl/src/main/java/org/ml4j/MatrixFactoryImpl.java
@@ -16,6 +16,7 @@ package org.ml4j;
 
 import org.ml4j.Matrix;
 import org.ml4j.MatrixFactory;
+import org.ml4j.mocks.MatrixFactoryMock;
 
 /**
  * The default ml4j MatrixFactory.
@@ -24,14 +25,21 @@ import org.ml4j.MatrixFactory;
  */
 public class MatrixFactoryImpl implements MatrixFactory {
 
+  private MatrixFactory delegatedFactory;
+
+  public MatrixFactoryImpl() {
+    this.delegatedFactory = new MatrixFactoryMock();
+  }
+
+
   @Override
   public Matrix createOnes(int rows, int columns) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return delegatedFactory.createOnes(rows, columns);
   }
 
   @Override
   public Matrix createMatrix(double[][] data) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return delegatedFactory.createMatrix(data);
   }
 
   @Override

--- a/ml4j-nn-impl/pom.xml
+++ b/ml4j-nn-impl/pom.xml
@@ -25,6 +25,16 @@
 			<artifactId>ml4j-nn-api</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>org.ml4j</groupId>
+			<artifactId>ml4j-mock-impl</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.ml4j</groupId>
+			<artifactId>ml4j-synapses-impl</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/ml4j-nn-impl/src/main/java/org/ml4j/nn/unsupervised/AutoEncoderContextImpl.java
+++ b/ml4j-nn-impl/src/main/java/org/ml4j/nn/unsupervised/AutoEncoderContextImpl.java
@@ -1,24 +1,28 @@
 /*
  * Copyright 2017 the original author or authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.ml4j.nn.unsupervised;
 
 import org.ml4j.MatrixFactory;
 import org.ml4j.nn.layers.DirectedLayerContext;
+import org.ml4j.nn.layers.mocks.DirectedLayerContextMock;
+import org.ml4j.nn.unsupervised.AutoEncoderContext;
 
 /**
- * Default implementation of AutoEncoderContext.
+ * Simple default implementation of AutoEncoderContext.
  * 
  * @author Michael Lavelle
  * 
@@ -31,32 +35,47 @@ public class AutoEncoderContextImpl implements AutoEncoderContext {
   private static final long serialVersionUID = 1L;
 
   /**
-   * Construct a new mock AutoEncoderContext.
+   * The MatrixFactory we configure for this context.
+   */
+  private MatrixFactory matrixFactory;
+
+  private int startLayerIndex;
+  
+  private Integer endLayerIndex;
+ 
+  /**
+   * Construct a default AutoEncoderContext.
    * 
    * @param matrixFactory The MatrixFactory we configure for this context
    */
-  public AutoEncoderContextImpl(MatrixFactory matrixFactory, int startLayerIndex,
-      Integer endLayerIndex) {
-    throw new UnsupportedOperationException("Not implemented yet");
+  public AutoEncoderContextImpl(MatrixFactory matrixFactory, 
+      int startLayerIndex, Integer endLayerIndex) {
+    this.matrixFactory = matrixFactory;
+    this.startLayerIndex = startLayerIndex;
+    this.endLayerIndex = endLayerIndex;
+    if (endLayerIndex != null && startLayerIndex > endLayerIndex) {
+      throw new IllegalArgumentException("Start layer index cannot be greater "
+          + "than end layer index");
+    }
   }
 
   @Override
   public MatrixFactory getMatrixFactory() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return matrixFactory;
   }
 
   @Override
   public DirectedLayerContext createLayerContext(int layerIndex) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return new DirectedLayerContextMock(matrixFactory);
   }
 
   @Override
   public int getStartLayerIndex() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return startLayerIndex;
   }
 
   @Override
   public Integer getEndLayerIndex() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return endLayerIndex;
   }
 }

--- a/ml4j-nn-impl/src/main/java/org/ml4j/nn/unsupervised/AutoEncoderImpl.java
+++ b/ml4j-nn-impl/src/main/java/org/ml4j/nn/unsupervised/AutoEncoderImpl.java
@@ -17,7 +17,7 @@ package org.ml4j.nn.unsupervised;
 import org.ml4j.mocks.MatrixMock;
 import org.ml4j.nn.ForwardPropagation;
 import org.ml4j.nn.axons.AxonsImpl;
-import org.ml4j.nn.axons.mocks.AxonsMock;
+
 import org.ml4j.nn.layers.FeedForwardLayer;
 import org.ml4j.nn.mocks.ForwardPropagationMock;
 import org.ml4j.nn.neurons.NeuronsActivation;

--- a/ml4j-synapses-impl/src/main/java/org/ml4j/nn/activationfunctions/SigmoidActivationFunction.java
+++ b/ml4j-synapses-impl/src/main/java/org/ml4j/nn/activationfunctions/SigmoidActivationFunction.java
@@ -14,8 +14,11 @@
 
 package org.ml4j.nn.activationfunctions;
 
+import org.ml4j.Matrix;
 import org.ml4j.nn.neurons.NeuronsActivation;
 import org.ml4j.nn.neurons.NeuronsActivationContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The default Sigmoid Activation Function.
@@ -25,9 +28,14 @@ import org.ml4j.nn.neurons.NeuronsActivationContext;
  */
 public class SigmoidActivationFunction implements DifferentiableActivationFunction {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(SigmoidActivationFunction.class);
+
   @Override
   public NeuronsActivation activate(NeuronsActivation input, NeuronsActivationContext context) {
-    throw new UnsupportedOperationException("Not implemented yet");
+    LOGGER.debug("Activating through SigmoidActivationFunctionMock");
+    Matrix sigmoidOfInputActivationsMatrix = input.getActivations().sigmoid();
+    return new NeuronsActivation(sigmoidOfInputActivationsMatrix, input.isBiasUnitIncluded(),
+        input.getFeatureOrientation());
   }
 
   @Override

--- a/ml4j-synapses-impl/src/main/java/org/ml4j/nn/axons/AxonsContextImpl.java
+++ b/ml4j-synapses-impl/src/main/java/org/ml4j/nn/axons/AxonsContextImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ml4j.nn.axons;
+
+/**
+ * Simple mock implementation of AxonsContext.
+ * 
+ * @author Michael Lavelle
+ */
+import org.ml4j.MatrixFactory;
+import org.ml4j.nn.axons.AxonsContext;
+
+public class AxonsContextImpl implements AxonsContext {
+
+  /**
+   * Default serialization id.
+   */
+  private static final long serialVersionUID = 1L;
+  
+  /**
+   * The MatrixFactory we configure for this context.
+   */
+  private MatrixFactory matrixFactory;
+  
+  /**
+   * Construct a new mock AxonsContext.
+   * 
+   * @param matrixFactory The MatrixFactory we configure for this context
+   */
+  public AxonsContextImpl(MatrixFactory matrixFactory) {
+    this.matrixFactory = matrixFactory;
+  }
+
+  @Override
+  public MatrixFactory getMatrixFactory() {
+    return matrixFactory;
+  }
+
+}

--- a/ml4j-synapses-impl/src/main/java/org/ml4j/nn/axons/AxonsImpl.java
+++ b/ml4j-synapses-impl/src/main/java/org/ml4j/nn/axons/AxonsImpl.java
@@ -1,0 +1,85 @@
+package org.ml4j.nn.axons;
+
+import org.ml4j.Matrix;
+import org.ml4j.nn.axons.AxonsContext;
+import org.ml4j.nn.axons.FullyConnectedAxons;
+import org.ml4j.nn.neurons.Neurons;
+import org.ml4j.nn.neurons.NeuronsActivation;
+import org.ml4j.nn.neurons.NeuronsActivationFeatureOrientation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AxonsImpl implements FullyConnectedAxons {
+
+  /**
+   * Default serialization id.
+   */
+  private static final long serialVersionUID = 1L;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(
+      AxonsImpl.class);
+  
+  private Neurons leftNeurons;
+  private Neurons rightNeurons;
+  private Matrix connectionWeights;
+  
+  /**
+   * Construct a new mock Axons instance.
+   * 
+   * @param leftNeurons The Neurons on the left hand side of these Axons
+   * @param rightNeurons The Neurons on the right hand side of these Axons
+   * @param connectionWeights The connection weights Matrix
+   */
+  public AxonsImpl(Neurons leftNeurons, Neurons rightNeurons, Matrix connectionWeights) {
+    this.leftNeurons = leftNeurons;
+    this.rightNeurons = rightNeurons;
+    this.connectionWeights = connectionWeights;
+  }
+  
+  @Override
+  public Neurons getLeftNeurons() {
+    return leftNeurons;
+  }
+
+  @Override
+  public Neurons getRightNeurons() {
+    return rightNeurons;
+  }
+
+  @Override
+  public NeuronsActivation pushLeftToRight(NeuronsActivation leftNeuronsActivation,
+      AxonsContext axonsContext) {
+    LOGGER.debug("Pushing left to right through Axons");
+    if (leftNeuronsActivation.getFeatureOrientation()
+            != NeuronsActivationFeatureOrientation.COLUMNS_SPAN_FEATURE_SET) {
+      throw new IllegalArgumentException("Only neurons actiavation with COLUMNS_SPAN_FEATURE_SET "
+          + "orientation supported currently");
+    }
+    Matrix outputMatrix =
+        leftNeuronsActivation.withBiasUnit(leftNeurons.hasBiasUnit(), axonsContext).getActivations()
+            .mmul(connectionWeights);
+    return new NeuronsActivation(outputMatrix, rightNeurons.hasBiasUnit(),
+        leftNeuronsActivation.getFeatureOrientation()).withBiasUnit(rightNeurons.hasBiasUnit(),
+            axonsContext);
+  }
+
+  @Override
+  public NeuronsActivation pushRightToLeft(NeuronsActivation rightNeuronsActivation,
+      AxonsContext axonsContext) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public FullyConnectedAxons dup() {
+    return new AxonsImpl(leftNeurons, rightNeurons, connectionWeights.dup());
+  }
+
+  public void setConnectionWeights(Matrix connectionWeights) {
+    this.connectionWeights = connectionWeights;
+  }
+
+  public Matrix getConnectionWeights() {
+    return connectionWeights;
+  }
+  
+}


### PR DESCRIPTION
Modifying default implementations required for AutoEncoderDemo so they delegate to fully functional mocks.  Simulating training by loading pre-trained weights.   With this configuration AutoEncoderDemo can now be used as a benchmark test harness to compare real training against.

PR opened so as to allow for easy compare of the files modified so as to aid the removal of mocks and the simulation of training using pre-trained weights 